### PR TITLE
Fix Chrome mobile no cookies error

### DIFF
--- a/lib/superstore-sync.js
+++ b/lib/superstore-sync.js
@@ -17,7 +17,16 @@ var persist = true;
 
 
 function Superstore(type) {
-	this.storage = window[type];
+  /* Chrome Mobile and Android browser will both barf if you try and read
+     window.locatStorage when Cookies are turned off.
+     Here's a wontfix on chromium about it: https://bugs.chromium.org/p/chromium/issues/detail?id=357625
+  */
+  try {
+    this.storage = window[type];
+  } catch (err){
+    /* use the in memory storage */
+    persist = false;
+  }
   this.keys = {};
   this.store = {};
   // TODO: check the storageArea so that we only refresh the key when we need to


### PR DESCRIPTION
In Chromium browsers with cookies turned off, calling
'window.localstorage' throws an error. This is covered more here:
https://bugs.chromium.org/p/chromium/issues/detail?id=357625

This commit wraps the window.localstorage request and if it errors, will
set the `persist` flag to false to fall back for in-memory storage.